### PR TITLE
🔧✅ Use package_coverage instead of file_coverage

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,3 +23,4 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.1.2
+Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,26 +1,26 @@
 Package: SeleccionAnalista2022
-Type: Package
 Title: Selección Analista 2022
-Version: 0.1.0
 Authors@R: c(
     person(given = "Ciencia de Datos",
            family = "GECI",
            role = c("aut", "cre", "cph"),
            email = "ciencia.datos@islas.org.mx"
            ))
+Config/testthat/edition: 3
 Description: Selección de estudiante para realizar proyecto de Ciencia de Datos en GECI
+Encoding: UTF-8
 Imports:
     data.table,
     MASS,
     R6,
     tidyverse
+LazyData: true
+License: GPL-3
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.1.2
 Suggests:
     devtools,
     roxygen2,
     testthat
-License: GPL-3
-Encoding: UTF-8
-LazyData: true
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
-Config/testthat/edition: 3
+Type: Package
+Version: 0.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN pip install --upgrade pip && pip install \
     pytest-cov \
     sklearn \
     tensorflow
-RUN Rscript -e "install.packages(c('covr', 'devtools', 'lintr', 'roxygen2', 'styler', 'testthat', 'vdiffr'), repos='http://cran.rstudio.com')"
+RUN Rscript -e "install.packages(c('covr', 'devtools', 'DT', 'lintr', 'roxygen2', 'styler', 'testthat', 'vdiffr'), repos='http://cran.rstudio.com')"
 

--- a/R/do_nothing.R
+++ b/R/do_nothing.R
@@ -1,3 +1,9 @@
 return_one <- function() {
   return(1)
 }
+return_two <- function() {
+  return(2)
+}
+return_three <- function() {
+  return(3)
+}

--- a/R/do_nothing.R
+++ b/R/do_nothing.R
@@ -1,9 +1,3 @@
 return_one <- function() {
   return(1)
 }
-return_two <- function() {
-  return(2)
-}
-return_three <- function() {
-  return(3)
-}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(SeleccionAnalista2022)
+
+test_check("SeleccionAnalista2022")

--- a/tests/testthat/coverage.R
+++ b/tests/testthat/coverage.R
@@ -1,13 +1,6 @@
 library(covr)
 library(testthat)
-cobertura <- file_coverage(
-  c(
-    "R/do_nothing.R",
-    "R/dummy_model.R"
-  ),
-  c(
-    "tests/testthat/test_nothing.R",
-    "tests/testthat/test_dummy_model.R"
-  )
-)
-covr::codecov(coverage = cobertura, token = "ad0d0063-7fec-4b66-8c6b-17045b746776")
+cov <- package_coverage()
+report(cov, file = file.path("/workdir/tests/coverage-report.html"), browse = FALSE )
+zero_coverage(cov)
+codecov(coverage = cov, token = "ad0d0063-7fec-4b66-8c6b-17045b746776")

--- a/tests/testthat/coverage.R
+++ b/tests/testthat/coverage.R
@@ -1,5 +1,4 @@
 library(covr)
-library(testthat)
 cov <- package_coverage()
 report(cov, file = file.path("/workdir/tests/coverage-report.html"), browse = FALSE)
 zero_coverage(cov)

--- a/tests/testthat/coverage.R
+++ b/tests/testthat/coverage.R
@@ -1,6 +1,6 @@
 library(covr)
 library(testthat)
 cov <- package_coverage()
-report(cov, file = file.path("/workdir/tests/coverage-report.html"), browse = FALSE )
+report(cov, file = file.path("/workdir/tests/coverage-report.html"), browse = FALSE)
 zero_coverage(cov)
 codecov(coverage = cov, token = "ad0d0063-7fec-4b66-8c6b-17045b746776")

--- a/tests/testthat/coverage.R
+++ b/tests/testthat/coverage.R
@@ -1,5 +1,6 @@
 library(covr)
 cov <- package_coverage()
-report(cov, file = file.path("/workdir/tests/coverage-report.html"), browse = FALSE)
+print(cov)
 zero_coverage(cov)
+report(cov, file = file.path("/workdir/tests/coverage-report.html"), browse = FALSE)
 codecov(coverage = cov, token = "ad0d0063-7fec-4b66-8c6b-17045b746776")

--- a/tests/testthat/test_dummy_model.R
+++ b/tests/testthat/test_dummy_model.R
@@ -1,4 +1,5 @@
 setwd("/workdir")
+library(tidyverse)
 
 dataset <- tibble(id = 1:2, target = 3:4)
 # Lee train.csv


### PR DESCRIPTION
El Actions no nos daba información sobre la cobertura de cada línea. En este PR usamos `package_coverage()` en lugar de `file_coverage()`. Ahora podemos ver cuáles líneas no fueron cubiertas en:
- la terminal,
- el reporte local `tests/coverage-report.html` y en
- [codecov](https://codecov.io/gh/IslasGECI/seleccion_analista_2022/tree/370b180263f911db3f8cfb8b8728e1e9b45a9d46/R).

# Actions
![image](https://user-images.githubusercontent.com/3461018/156953268-8193d029-3acc-4d64-b677-adee65e07cb1.png)


# Local
![image](https://user-images.githubusercontent.com/3461018/156952263-eb3e894d-1335-460d-97ae-47e7ea6e4048.png)

# Reporte HTML
![image](https://user-images.githubusercontent.com/3461018/156951531-4d5b313c-3a75-4325-b7eb-7852717c6351.png)

# codecov
![image](https://user-images.githubusercontent.com/3461018/156953379-99914e03-31ce-42f1-84e6-d0fff22eee7f.png)
